### PR TITLE
Adds reset functionality

### DIFF
--- a/__tests__/routes/mod-test.js
+++ b/__tests__/routes/mod-test.js
@@ -143,8 +143,8 @@ module.exports = (flag) => {
 
           expect(res.status).toBe(204);
           expect(res.body).toBeNull();
-        })
-      })
+        });
+      });
     }
   });
 };

--- a/__tests__/routes/mod-test.js
+++ b/__tests__/routes/mod-test.js
@@ -136,6 +136,15 @@ module.exports = (flag) => {
           expect(res.body[1].Status).toBe('APPROVED');
         });
       });
+
+      describe('PUT /mod/reset', () => {
+        it('should return a 204 on success', async () => {
+          const res = await request(server).put('/mod/reset');
+
+          expect(res.status).toBe(204);
+          expect(res.body).toBeNull();
+        })
+      })
     }
   });
 };

--- a/api/mod/modModel.js
+++ b/api/mod/modModel.js
@@ -119,7 +119,7 @@ const resetGameForTesting = async () => {
     public."Members" 
     CASCADE`
   );
-}
+};
 
 module.exports = {
   clusterGeneration,

--- a/api/mod/modModel.js
+++ b/api/mod/modModel.js
@@ -124,4 +124,5 @@ module.exports = {
   moderatePost,
   generateFaceoffs,
   calculateResultsForTheWeek,
+  resetGameForTesting,
 };

--- a/api/mod/modModel.js
+++ b/api/mod/modModel.js
@@ -98,6 +98,24 @@ const calculateResultsForTheWeek = () => {
   });
 };
 
+/**
+ * Truncates tables in order to reset the game state.
+ * This should be run for testing purposes only.
+ * It will delete all rows in the following tables:
+ * 1. Votes
+ * 2. Teams
+ * 3. Points
+ * 4. Faceoffs
+ * 5. Squads
+ */
+const resetGameForTesting = () => {
+  db('Votes').truncate();
+  db('Teams').truncate();
+  db('Points').truncate();
+  db('Faceoffs').truncate();
+  db('Squads').truncate();
+}
+
 module.exports = {
   clusterGeneration,
   getCohorts,

--- a/api/mod/modModel.js
+++ b/api/mod/modModel.js
@@ -99,21 +99,26 @@ const calculateResultsForTheWeek = () => {
 };
 
 /**
- * Truncates tables in order to reset the game state.
+ * Truncates tables in order to reset the game state. Keeps all submissions intact.
  * This should be run for testing purposes only.
- * It will delete all rows in the following tables:
+ * It will truncate all rows in the following tables:
  * 1. Votes
  * 2. Teams
  * 3. Points
  * 4. Faceoffs
  * 5. Squads
  */
-const resetGameForTesting = () => {
-  db('Votes').truncate();
-  db('Teams').truncate();
-  db('Points').truncate();
-  db('Faceoffs').truncate();
-  db('Squads').truncate();
+const resetGameForTesting = async () => {
+  return db.raw(
+    `TRUNCATE 
+    public."Votes", 
+    public."Teams", 
+    public."Points", 
+    public."Faceoffs", 
+    public."Squads", 
+    public."Members" 
+    CASCADE`
+  );
 }
 
 module.exports = {

--- a/api/mod/modRouter.js
+++ b/api/mod/modRouter.js
@@ -252,4 +252,21 @@ router.put('/submissions/:id', (req, res) => {
   ops.update(res, Mod.moderatePost, 'Submission', id, changes);
 });
 
+/**
+ * @swagger
+ * /mod/reset:
+ *  put:
+ *    summary: Resets the game state to before cluster generation. Should be used for testing only.
+ *    tags:
+ *      - Moderation
+ *    responses:
+ *      200:
+ *        $ref: '#/components/responses/EmptySuccess'
+ *      500:
+ *        $ref: '#/components/responses/DatabaseError'
+ */
+router.put('/reset', (req, res) => {
+  ops.update(res, Mod.resetGameForTesting, 'Reset');
+})
+
 module.exports = router;

--- a/api/mod/modRouter.js
+++ b/api/mod/modRouter.js
@@ -267,6 +267,6 @@ router.put('/submissions/:id', (req, res) => {
  */
 router.put('/reset', (req, res) => {
   ops.update(res, Mod.resetGameForTesting, 'Reset');
-})
+});
 
 module.exports = router;


### PR DESCRIPTION
# Description
Adds an endpoint and a model method that truncates the following tables in order to reset the game state to before cluster generation:
- Votes
- Teams
- Points
- Faceoffs
- Squads
- Members

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

## Has This Been Tested

- [x] Yes
- [ ] No
- [ ] Not necessary

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
